### PR TITLE
Update .equals? predicate to account for lookups that return 0

### DIFF
--- a/lib/predicates.js
+++ b/lib/predicates.js
@@ -47,8 +47,33 @@ var rQuotes = /"|'/g,
             arg1 = ("" + arg1.replace( rQuotes, "" ));
             arg2 = ("" + arg2.replace( rQuotes, "" ));
 
-            arg1 = !isNumeric( arg1 ) ? (ctx._LookUpStack( arg1 ) || ctx.get( arg1 ) || arg1) : arg1;
-            arg2 = !isNumeric( arg2 ) ? (ctx._LookUpStack( arg2 ) || ctx.get( arg2 ) || arg2) : arg2;
+            if ( !isNumeric( arg1 ) ) {
+                var lookup = ctx._LookUpStack( arg1 ),
+                    get = ctx.get( arg1 ),
+                    lookupIsNumeric = isNumeric(lookup),
+                    getIsNumeric = isNumeric(get);
+
+                if ( lookup || lookupIsNumeric ) {
+                    arg1 = lookup;
+
+                } else if ( get || getIsNumeric ) {
+                    arg1 = get;
+                }
+            }
+
+            if ( !isNumeric( arg2 ) ) {
+                var lookup = ctx._LookUpStack( arg2 ),
+                    get = ctx.get( arg2 ),
+                    lookupIsNumeric = isNumeric(lookup),
+                    getIsNumeric = isNumeric(get);
+
+                if ( lookup || lookupIsNumeric ) {
+                    arg2 = lookup;
+
+                } else if ( get || getIsNumeric ) {
+                    arg2 = get;
+                }
+            }
 
             return (arg1 == arg2 || arg1 == ctx.get( arg2 ));
         },

--- a/lib/predicates.js
+++ b/lib/predicates.js
@@ -11,6 +11,21 @@ var rQuotes = /"|'/g,
     isNumeric = function ( obj ) {
         return !Array.isArray( obj ) && obj - parseFloat( obj ) >= 0;
     },
+    getLookupArg = function ( ctx, arg ) {
+        var get = ctx.get( arg ),
+            lookup = ctx._LookUpStack( arg ),
+            lookupIsNumeric = isNumeric( lookup ),
+            getIsNumeric = isNumeric( get );
+
+        if ( lookup || lookupIsNumeric ) {
+            arg = lookup;
+
+        } else if ( get || getIsNumeric ) {
+            arg = get;
+        }
+
+        return arg;
+    },
     jsonTemplate = require( "./jsontemplate" ),
     jsontPredicates = [
         "singular",
@@ -48,31 +63,11 @@ var rQuotes = /"|'/g,
             arg2 = ("" + arg2.replace( rQuotes, "" ));
 
             if ( !isNumeric( arg1 ) ) {
-                var lookup = ctx._LookUpStack( arg1 ),
-                    get = ctx.get( arg1 ),
-                    lookupIsNumeric = isNumeric(lookup),
-                    getIsNumeric = isNumeric(get);
-
-                if ( lookup || lookupIsNumeric ) {
-                    arg1 = lookup;
-
-                } else if ( get || getIsNumeric ) {
-                    arg1 = get;
-                }
+                arg1 = getLookupArg( ctx, arg1 );
             }
 
             if ( !isNumeric( arg2 ) ) {
-                var lookup = ctx._LookUpStack( arg2 ),
-                    get = ctx.get( arg2 ),
-                    lookupIsNumeric = isNumeric(lookup),
-                    getIsNumeric = isNumeric(get);
-
-                if ( lookup || lookupIsNumeric ) {
-                    arg2 = lookup;
-
-                } else if ( get || getIsNumeric ) {
-                    arg2 = get;
-                }
+                arg2 = getLookupArg( ctx, arg2 );
             }
 
             return (arg1 == arg2 || arg1 == ctx.get( arg2 ));


### PR DESCRIPTION
I had an issue when using displayIndex with the .equals? predicate where it would fail when the ctx._LookUpStack returned 0. This was due to the equality cascade used to set a default.

`(ctx._LookUpStack( arg1 ) || ctx.get( arg1 ) || arg1)` would evaluate to `0 || 0 || 'displayIndex'` resulting in a final equality test of `'displayIndex' === 0`, which is `false`. The `||` cascade treats 0 as false even though in this case it is the value we want to set the `arg1` to.

This fix checks if the lookup and get are truthy on their own or if they are numeric (which 0 is). If any of that is true, the argument is set to it. Otherwise, left as the original argument passed in.

There might be a better way -- I just dug in deep enough to get this working in my case. It doesn't seem to break anything, but again, there may be test cases I'm unaware of.
