### PR TITLE
Add handling for non-space delimiters for equal predicate. Fixes #30.

### DIFF
--- a/lib/jsontemplate.js
+++ b/lib/jsontemplate.js
@@ -718,14 +718,18 @@ function _Compile(template_str, options) {
       // @see http://jsont.squarespace.com/advanced-jsont/ - @kitajchuk
       var if_token = false, pred_token = false;
       var if_match = token.match(_IF_RE);
-      var token_split = token.split(' ').shift(); // split token from arguments - @kitajchuk
       if (if_match) {
         pred_str = token;
         if_token = true;
       // also check token split in case of arguments - @kitajchuk
-      } else if (token.charAt(token.length-1) == '?' || token_split.charAt(token_split.length-1) == '?') {
-        pred_str = token;
-        pred_token = true;
+      } else {
+        //get delimiter for equal if not a space
+        var delimiter = token.split('?')[1] ? token.split('?')[1][0] : ' ';
+        var token_split = token.split(delimiter).shift(); // split token from arguments - @kitajchuk
+        if (token.charAt(token.length-1) == '?' || token_split.charAt(token_split.length-1) == '?') {
+          pred_str = token;
+          pred_token = true;
+        }
       }
       if (if_token || pred_token) {
         // test_attr=true if we got the {.attr?} style (pred_token)

--- a/lib/predicates/index.js
+++ b/lib/predicates/index.js
@@ -41,7 +41,8 @@ var defaultPredicates = [
 
 
 module.exports = function ( arg ) {
-    var index = arg.indexOf( " " ),
+    // get index for predicate, with handling for equal with non-space delimiters
+    var index = arg.indexOf(arg.split('?')[1] ? arg.split('?')[1][0] : ' '),
         predicate = null,
         args = null;
 
@@ -52,16 +53,21 @@ module.exports = function ( arg ) {
     } else {
         predicate = arg.substr( 0, index );
 
+        //get delimiter for equal if not a space
+        var delimiter = arg.split('?')[1] ? arg.split('?')[1][0] : ' ';
+        var reg1 = new RegExp('^\\s+|\\s+$|' + delimiter, "g");
+        var reg2 = new RegExp('\\s|' + delimiter, "g");
+
         // Clean predicate out of args now
         arg = arg.replace( predicate, "" ).replace( /^\s+|\s+$/g, "" );
 
         // Filter and normalize the arguments list
         args = arg.split( (/\"/.test( arg ) ? /\"(.*?)\"/g : /\s/g) )
             .map(function ( el ) {
-                return el.replace( /^\s+|\s+$/g, "" );
+                return el.replace(reg1, "" );
             })
             .filter(function ( el ) {
-                var tmp = el.replace( /\s/g, "" );
+                var tmp = el.replace(reg2, "" );
 
                 return ( tmp !== "" );
             });


### PR DESCRIPTION
I would appreciate any feedback here. I don't know that this would be the cleanest implementation, but testing locally, it worked for me.
